### PR TITLE
Update readme vars with correct ports

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -46,14 +46,15 @@ param_volumes:
 
 param_usage_include_ports: true
 param_ports:
-  - { external_port: "3478", internal_port: "3478/udp", port_desc: "Unifi communication port" }
-  - { external_port: "10001", internal_port: "10001/udp", port_desc: "required for AP discovery" }
-  - { external_port: "8080", internal_port: "8080", port_desc: "required for Unifi to function" }
-  - { external_port: "8081", internal_port: "8081", port_desc: "Unifi communication port" }
-  - { external_port: "8443", internal_port: "8443", port_desc: "Unifi communication port" }
-  - { external_port: "8843", internal_port: "8843", port_desc: "Unifi communication port" }
-  - { external_port: "8880", internal_port: "8880", port_desc: "Unifi communication port" }
-  - { external_port: "6789", internal_port: "6789", port_desc: "For throughput test" }
+  - { external_port: "3478", internal_port: "3478/udp", port_desc: "Unifi STUN port" }
+  - { external_port: "10001", internal_port: "10001/udp", port_desc: "Required for AP discovery" }
+  - { external_port: "1900", internal_port: "1900/udp", port_desc: "Required for "Make controller discoverable on L2 network" option" }
+  - { external_port: "8080", internal_port: "8080", port_desc: "Required for device communication" }
+  - { external_port: "8443", internal_port: "8443", port_desc: "Unifi web admin port" }
+  - { external_port: "8843", internal_port: "8843", port_desc: "Unifi guest portal HTTPS redirect port" }
+  - { external_port: "8880", internal_port: "8880", port_desc: "Unifi guest portal HTTP redirect port" }
+  - { external_port: "6789", internal_port: "6789", port_desc: "For mobile throughput test" }
+  - { external_port: "5514", internal_port: "5514", port_desc: "Remote syslog port" }
 param_usage_include_env: false
 
 # application setup block
@@ -67,7 +68,6 @@ app_setup_block: |
 
   ```
   ssh ubnt@$AP-IP
-  mca-cli
   set-inform http://$address:8080/inform
   ```
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -48,14 +48,17 @@ param_usage_include_ports: true
 param_ports:
   - { external_port: "3478", internal_port: "3478/udp", port_desc: "Unifi STUN port" }
   - { external_port: "10001", internal_port: "10001/udp", port_desc: "Required for AP discovery" }
-  - { external_port: "1900", internal_port: "1900/udp", port_desc: "Required for "Make controller discoverable on L2 network" option" }
   - { external_port: "8080", internal_port: "8080", port_desc: "Required for device communication" }
   - { external_port: "8443", internal_port: "8443", port_desc: "Unifi web admin port" }
+param_usage_include_env: false
+
+opt_param_usage_include_ports: true
+opt_param_ports:
+  - { external_port: "1900", internal_port: "1900/udp", port_desc: "Required for "Make controller discoverable on L2 network" option" }
   - { external_port: "8843", internal_port: "8843", port_desc: "Unifi guest portal HTTPS redirect port" }
   - { external_port: "8880", internal_port: "8880", port_desc: "Unifi guest portal HTTP redirect port" }
   - { external_port: "6789", internal_port: "6789", port_desc: "For mobile throughput test" }
   - { external_port: "5514", internal_port: "5514", port_desc: "Remote syslog port" }
-param_usage_include_env: false
 
 # application setup block
 app_setup_block_enabled: true
@@ -75,6 +78,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "02.06.20:", desc: "Updated port list & descriptions. Moved some ports to optional."}
   - { date: "14.11.19:", desc: "Changed url for deb package to match new Ubiquity domain." }
   - { date: "29.07.19:", desc: "Allow for changing Java mem limit via new optional environment variable." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }


### PR DESCRIPTION
Update readme vars with corrected port list and descriptions and correct inform update command.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
Ports as per: https://help.ui.com/hc/en-us/articles/218506997

8081 appears to be an obsolete port, I can't find any reference in the docs to it any more, just a few very old (5 years) forum posts.

Also removed the "mca-cli" line from the adoption section as it's no longer required on the APs.

## Benefits of this PR and context:
Current port info is incomplete and it's unclear which ports are necessary for which kinds of deployment. Most users won't need all of the listed ports in their environment but will hopefully be aware of which they do need.

## How Has This Been Tested?
Tested in my own live environment; no impact from removing port 8081 from published ports.

## Source / References:
https://help.ui.com/hc/en-us/articles/218506997
https://help.ui.com/hc/en-us/articles/204909754-UniFi-Device-Adoption-Methods-for-Remote-UniFi-Controllers
