### PR TITLE
Update mongoDB version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/ubuntu:xenial
+FROM lsiobase/ubuntu:bionic
 
 # set version label
 ARG BUILD_DATE
@@ -12,16 +12,14 @@ ARG UNIFI_BRANCH="stable"
 ARG DEBIAN_FRONTEND="noninteractive"
 
 RUN \
- echo "**** add mongo repository ****" && \
- apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5 && \
- echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" >> /etc/apt/sources.list.d/mongo.list && \
  echo "**** install packages ****" && \
  apt-get update && \
  apt-get install -y \
 	binutils \
 	jsvc \
+	libcap2 \
 	logrotate \
-	mongodb-org-server \
+	mongodb-server \
 	openjdk-8-jre-headless \
 	wget && \
  echo "**** install unifi ****" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ ARG DEBIAN_FRONTEND="noninteractive"
 
 RUN \
  echo "**** add mongo repository ****" && \
- apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6 && \
- echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" >> /etc/apt/sources.list.d/mongo.list && \
+ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5 && \
+ echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" >> /etc/apt/sources.list.d/mongo.list && \
  echo "**** install packages ****" && \
  apt-get update && \
  apt-get install -y \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -17,6 +17,7 @@ RUN \
  apt-get install -y \
 	binutils \
 	jsvc \
+	libcap2 \
 	logrotate \
 	mongodb-server \
 	openjdk-8-jre-headless \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -13,8 +13,8 @@ ARG DEBIAN_FRONTEND="noninteractive"
 
 RUN \
  echo "**** add mongo repository ****" && \
- apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6 && \
- echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" >> /etc/apt/sources.list.d/mongo.list && \
+ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5 && \
+ echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" >> /etc/apt/sources.list.d/mongo.list && \
  echo "**** install packages ****" && \
  apt-get update && \
  apt-get install -y \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/ubuntu:arm64v8-xenial
+FROM lsiobase/ubuntu:arm64v8-bionic
 
 # set version label
 ARG BUILD_DATE
@@ -12,16 +12,13 @@ ARG UNIFI_BRANCH="stable"
 ARG DEBIAN_FRONTEND="noninteractive"
 
 RUN \
- echo "**** add mongo repository ****" && \
- apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5 && \
- echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" >> /etc/apt/sources.list.d/mongo.list && \
  echo "**** install packages ****" && \
  apt-get update && \
  apt-get install -y \
 	binutils \
 	jsvc \
 	logrotate \
-	mongodb-org-server \
+	mongodb-server \
 	openjdk-8-jre-headless \
 	wget && \
  echo "**** install unifi ****" && \

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **17.07.20:** - Rebase 64 bit containers to Bionic and Mongo 3.6.
 * **16.06.20:** - Add logrotate.
 * **02.06.20:** - Updated port list & descriptions. Moved some ports to optional.
 * **14.11.19:** - Changed url for deb package to match new Ubiquity domain.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -78,6 +78,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "17.07.20:", desc: "Rebase 64 bit containers to Bionic and Mongo 3.6."}
   - { date: "16.06.20:", desc: "Add logrotate."}
   - { date: "02.06.20:", desc: "Updated port list & descriptions. Moved some ports to optional."}
   - { date: "14.11.19:", desc: "Changed url for deb package to match new Ubiquity domain." }


### PR DESCRIPTION
Updating mongoDB to 3.6 which is supported in the 5.13 branch.

mongoDB 3.4 went end of life in January 2020: https://www.mongodb.com/support-policy