### PR TITLE
add note about override host to make adoption possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as bel
 
 The webui is at https://ip:8443, setup with the first run wizard.
 
-For Unifi to adopt other devices, e.g. an Access Point, it is required to change the inform ip address. Because Unifi runs inside Docker by default it uses an ip address not accessable by other devices. To change this go to Settings > Controller > Controller Settings and set the Controller Hostname/IP to an ip address accessable by other devices.
+For Unifi to adopt other devices, e.g. an Access Point, it is required to change the inform ip address. Because Unifi runs inside Docker by default it uses an ip address not accessable by other devices. To change this go to Settings > Controller > Controller Settings and set the Controller Hostname/IP to an ip address accessable by other devices. Additionally the checkbox "Override inform host with controller hostname/IP" has to be checked, so that devices can connect to the controller during adoption.
 
 Alternatively to manually adopt a device take these steps:
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as bel
 
 The webui is at https://ip:8443, setup with the first run wizard.
 
-For Unifi to adopt other devices, e.g. an Access Point, it is required to change the inform ip address. Because Unifi runs inside Docker by default it uses an ip address not accessable by other devices. To change this go to Settings > Controller > Controller Settings and set the Controller Hostname/IP to an ip address accessable by other devices. Additionally the checkbox "Override inform host with controller hostname/IP" has to be checked, so that devices can connect to the controller during adoption.
+For Unifi to adopt other devices, e.g. an Access Point, it is required to change the inform ip address. Because Unifi runs inside Docker by default it uses an ip address not accessable by other devices. To change this go to Settings > Controller > Controller Settings and set the Controller Hostname/IP to an ip address accessable by other devices.
 
 Alternatively to manually adopt a device take these steps:
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -65,7 +65,7 @@ app_setup_block_enabled: true
 app_setup_block: |
   The webui is at https://ip:8443, setup with the first run wizard.
 
-  For Unifi to adopt other devices, e.g. an Access Point, it is required to change the inform ip address. Because Unifi runs inside Docker by default it uses an ip address not accessable by other devices. To change this go to Settings > Controller > Controller Settings and set the Controller Hostname/IP to an ip address accessable by other devices.
+  For Unifi to adopt other devices, e.g. an Access Point, it is required to change the inform ip address. Because Unifi runs inside Docker by default it uses an ip address not accessable by other devices. To change this go to Settings > Controller > Controller Settings and set the Controller Hostname/IP to an ip address accessable by other devices. Additionally the checkbox "Override inform host with controller hostname/IP" has to be checked, so that devices can connect to the controller during adoption (devices use the inform-endpoint during adoption).
 
   Alternatively to manually adopt a device take these steps:
 


### PR DESCRIPTION
Description: add description of required setting to allow adoption when running unifi controller in a docker container
Benefits of this PR and context: less headaches for new users
How Has This Been Tested? read it, done it
Source / References: issue #38