### PR TITLE
Correct protocol for port 5514

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -58,7 +58,7 @@ opt_param_ports:
   - { external_port: "8843", internal_port: "8843", port_desc: "Unifi guest portal HTTPS redirect port" }
   - { external_port: "8880", internal_port: "8880", port_desc: "Unifi guest portal HTTP redirect port" }
   - { external_port: "6789", internal_port: "6789", port_desc: "For mobile throughput test" }
-  - { external_port: "5514", internal_port: "5514", port_desc: "Remote syslog port" }
+  - { external_port: "5514", internal_port: "5514/udp", port_desc: "Remote syslog port" }
 
 # application setup block
 app_setup_block_enabled: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-unifi-controller/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Port 5514 *needs* to be **udp**, as noted in the upstream documentation.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Allows remote devices to correctly relay their debug logs to the controller running in this container.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Noticed when looking at logs on an access point that showed: `failed to send log data to $address:5514 via udp`. Updating my local deployment to use udp for port 5514 corrected this.

Ran the change through `doc-builder` to pop out a `GENERATED.md` and all points in the `README.md` where the port is referenced looked fine.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://help.ui.com/hc/en-us/articles/218506997-UniFi-Ports-Used