### PR TITLE
Allow for changing Java initial mem via new optional environment variable

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -18,7 +18,7 @@ available_architectures:
 opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "MEM_LIMIT", env_value: "1024M", desc: "Optionally change the Java memory limit (-Xmx) (default is 1024M)." }
-  - { env_var: "MEM_STARTUP", env_value: "512M", desc: "Optionally change the Java initial memory (-Xms) (default is 512M)." }
+  - { env_var: "MEM_STARTUP", env_value: "1024M", desc: "Optionally change the Java initial memory (-Xms) (default is 1024M)." }
 
 # Optional Block
 optional_block_1: true
@@ -79,7 +79,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
-  - { date: "04.03.21:", desc: "Allow for changing Java initial mem via new optional environment variable."}
+  - { date: "11.06.21:", desc: "Allow for changing Java initial mem via new optional environment variable."}
   - { date: "12.01.21:", desc: "Deprecate the `LTS` tag as Unifi no longer releases LTS stable builds. Existing users can switch to the `latest` tag. Direct upgrade from 5.6.42 (LTS) to 6.0.42 (latest) tested successfully."}
   - { date: "17.07.20:", desc: "Rebase 64 bit containers to Bionic and Mongo 3.6."}
   - { date: "16.06.20:", desc: "Add logrotate."}

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -18,6 +18,7 @@ available_architectures:
 opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "MEM_LIMIT", env_value: "1024M", desc: "Optionally change the Java memory limit (-Xmx) (default is 1024M)." }
+  - { env_var: "MEM_STARTUP", env_value: "512M", desc: "Optionally change the Java initial memory (-Xms) (default is 512M)." }
 
 # Optional Block
 optional_block_1: true
@@ -78,6 +79,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "04.03.21:", desc: "Allow for changing Java initial mem via new optional environment variable."}
   - { date: "12.01.21:", desc: "Deprecate the `LTS` tag as Unifi no longer releases LTS stable builds. Existing users can switch to the `latest` tag. Direct upgrade from 5.6.42 (LTS) to 6.0.42 (latest) tested successfully."}
   - { date: "17.07.20:", desc: "Rebase 64 bit containers to Bionic and Mongo 3.6."}
   - { date: "16.06.20:", desc: "Add logrotate."}

--- a/root/etc/services.d/unifi/run
+++ b/root/etc/services.d/unifi/run
@@ -6,5 +6,9 @@ if [ -z ${MEM_LIMIT+x} ]; then
   MEM_LIMIT="1024M"
 fi
 
+if [ -z ${MEM_STARTUP+x} ]; then
+  MEM_STARTUP="512M"
+fi
+
 exec \
-	s6-setuidgid abc java -Xmx"${MEM_LIMIT}" -jar /usr/lib/unifi/lib/ace.jar start
+	s6-setuidgid abc java -Xms"${MEM_STARTUP}" -Xmx"${MEM_LIMIT}" -jar /usr/lib/unifi/lib/ace.jar start

--- a/root/etc/services.d/unifi/run
+++ b/root/etc/services.d/unifi/run
@@ -7,7 +7,7 @@ if [ -z ${MEM_LIMIT+x} ]; then
 fi
 
 if [ -z ${MEM_STARTUP+x} ]; then
-  MEM_STARTUP="512M"
+  MEM_STARTUP="1024M"
 fi
 
 exec \


### PR DESCRIPTION
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-unifi-controller/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:

This PR adds an optional environment variable MEM_STARTUP (default 512MB) to set the JVM startup memory (-Xms) to a value lower than the JVM memory limit (-Xml) that can already be set via MEM_LIMIT (default 1024MB).

## Benefits of this PR and context:
This PR allows to run the Unifi controller easily in resource limited environments like a Raspberry PI or simply reduces the memory usage for small and simple Unifi deployments.

## How Has This Been Tested?
I have tested the changes in my own unifi system with 9 APs but no Unifi switches or gateways.
Memory usage of the java process reacts as expected (mongodb memory usage is as expected unaffected).
I have no problems with MEM_STARTUP=256MB and MEM_LIMIT=512MB (half the defaults). I have not tested lower values.

## Source / References:

See notice from UBNT:
https://community.ui.com/questions/NOTICE-UniFi-Controller-Memory-Usage-5-6-20/228907d2-8d30-42a0-b97c-b14ef9767edb
