### PR TITLE
Fix MEM_STARTUP issue

### DIFF
--- a/root/etc/services.d/unifi/run
+++ b/root/etc/services.d/unifi/run
@@ -7,8 +7,9 @@ if [ -z ${MEM_LIMIT+x} ]; then
 fi
 
 if [ -z ${MEM_STARTUP+x} ]; then
-  MEM_STARTUP="1024M"
+    exec \
+        s6-setuidgid abc java -Xmx"${MEM_LIMIT}" -jar /usr/lib/unifi/lib/ace.jar start;
+else
+    exec \
+        s6-setuidgid abc java -Xms"${MEM_STARTUP}" -Xmx"${MEM_LIMIT}" -jar /usr/lib/unifi/lib/ace.jar start;
 fi
-
-exec \
-	s6-setuidgid abc java -Xms"${MEM_STARTUP}" -Xmx"${MEM_LIMIT}" -jar /usr/lib/unifi/lib/ace.jar start


### PR DESCRIPTION
Fix issue where MEM_LIMIT is set to less than 1024M and MEM_STARTUP isn't set, causing errors due to intial heap size being more than the maximum. If MEM_STARTUP isn't set, don't try and pass any value for it to the service.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-unifi-controller/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Fix issue where MEM_LIMIT is set to less than 1024M and MEM_STARTUP isn't set, causing errors due to intial heap size being more than the maximum. If MEM_STARTUP isn't set, don't try and pass any value for it to the service. Closes #85.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
