### PR TITLE
Remove custom management for Java heap sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      - MEM_LIMIT=1024M #optional
-      - MEM_STARTUP=1024M #optional
     volumes:
       - <path to data>:/config
     ports:
@@ -115,8 +113,6 @@ docker run -d \
   --name=unifi-controller \
   -e PUID=1000 \
   -e PGID=1000 \
-  -e MEM_LIMIT=1024M `#optional` \
-  -e MEM_STARTUP=1024M `#optional` \
   -p 3478:3478/udp \
   -p 10001:10001/udp \
   -p 8080:8080 \
@@ -148,8 +144,6 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-p 5514/udp` | Remote syslog port |
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
-| `-e MEM_LIMIT=1024M` | Optionally change the Java memory limit (-Xmx) (default is 1024M). |
-| `-e MEM_STARTUP=1024M` | Optionally change the Java initial memory (-Xms) (default is 1024M). |
 | `-v /config` | All Unifi data stored here |
 
 ## Environment variables from files (Docker secrets)

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -23,10 +23,8 @@ param_volumes:
   - { vol_path: "/config", vol_host_path: "<path to data>", desc: "All Unifi data stored here" }
 
 # optional container parameters
-opt_param_usage_include_env: true
+opt_param_usage_include_env: false
 opt_param_env_vars:
-  - { env_var: "MEM_LIMIT", env_value: "1024M", desc: "Optionally change the Java memory limit (-Xmx) (default is 1024M)." }
-  - { env_var: "MEM_STARTUP", env_value: "1024M", desc: "Optionally change the Java initial memory (-Xms) (default is 1024M)." }
 
 param_usage_include_ports: true
 param_ports:
@@ -64,6 +62,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "23.12.21:", desc: "Remove MEM_LIMIT and MEM_STARTUP environment variables to favor the system.properties file values."}
   - { date: "22.12.21:", desc: "Move deb package install to first init to avoid overlayfs performance issues."}
   - { date: "13.12.21:", desc: "Rebase 64 bit containers to Focal."}
   - { date: "11.12.21:", desc: "Add java opts to mitigate CVE-2021-44228."}

--- a/root/etc/services.d/unifi/run
+++ b/root/etc/services.d/unifi/run
@@ -2,14 +2,4 @@
 
 cd /config || exit
 
-if [ -z ${MEM_LIMIT+x} ]; then
-  MEM_LIMIT="1024M"
-fi
-
-if [ -z ${MEM_STARTUP+x} ]; then
-    exec \
-        s6-setuidgid abc java -Xmx"${MEM_LIMIT}" -Dlog4j2.formatMsgNoLookups=true -jar /usr/lib/unifi/lib/ace.jar start;
-else
-    exec \
-        s6-setuidgid abc java -Xms"${MEM_STARTUP}" -Xmx"${MEM_LIMIT}" -Dlog4j2.formatMsgNoLookups=true -jar /usr/lib/unifi/lib/ace.jar start;
-fi
+exec s6-setuidgid abc java -Dlog4j2.formatMsgNoLookups=true -jar /usr/lib/unifi/lib/ace.jar start;


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]



<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-unifi-controller/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

## Description / Benefits of this PR and context:
Unifi Controller already handles the ``xms`` and ``xmx`` values on it's own [by using the ``system.properties`` file](https://web.archive.org/web/20201004125720/https://help.ui.com/hc/en-us/articles/115005159588-UniFi-How-to-Tune-the-Controller-for-High-Number-of-UniFi-Devices). Users that want to have different values for the Java allocator should use ``unifi.xmx`` and ``unifi.xms`` keys in the ``system.properties`` instead. 

Our own override of the values in the Java arguments is confusing, because what if someone else have configured one value in the environment variable but a different one in system.properties? Which one takes precedence over which? There's no official documentation (beside Java's own docs) about the CLI parameters, so it might be causing conflicts within Unifi Controller itself.

It's also unclear wether Unifi Controller is using the values we're providing in CLI instead of the values present in ``system.properties``. Also, Ubiquiti might change the defaults in new versions without further notice, which may cause incompatibilities with our own values, making this container prone to breaking and headaches in the future.

## How Has This Been Tested?
Changing the ``unifi.xms`` parameter in ``system.properties`` does indeed reduce the initial memory allocation, as of Unifi Controller 6.2.26


## Source / References:
* [Unifi docs](https://web.archive.org/web/20201004125720/https://help.ui.com/hc/en-us/articles/115005159588-UniFi-How-to-Tune-the-Controller-for-High-Number-of-UniFi-Devices)
