### PR TITLE
Updating default port mapping to resolve potential conflicts with popular containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,4 @@ COPY root/ /
 # Volumes and Ports
 WORKDIR /usr/lib/unifi
 VOLUME /config
-EXPOSE 8080 8443 8843 8880
+EXPOSE 8081 8442 8843 8880

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -46,4 +46,4 @@ COPY root/ /
 # Volumes and Ports
 WORKDIR /usr/lib/unifi
 VOLUME /config
-EXPOSE 8080 8443 8843 8880
+EXPOSE 8081 8442 8843 8880

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -45,4 +45,4 @@ COPY root/ /
 # Volumes and Ports
 WORKDIR /usr/lib/unifi
 VOLUME /config
-EXPOSE 8080 8443 8843 8880
+EXPOSE 8081 8442 8843 8880

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
     MULTIARCH='true'
     CI='true'
     CI_WEB='true'
-    CI_PORT='8443'
+    CI_PORT='8442'
     CI_SSL='true'
     CI_DELAY='180'
     CI_DOCKERENV='TZ=US/Pacific'

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The architectures supported by this image are:
 
 ## Application Setup
 
-The webui is at https://ip:8443, setup with the first run wizard.
+The webui is at https://ip:8442, setup with the first run wizard.
 
 For Unifi to adopt other devices, e.g. an Access Point, it is required to change the inform IP address. Because Unifi runs inside Docker by default it uses an IP address not accessible by other devices. To change this go to Settings > System Settings > Controller Configuration and set the Controller Hostname/IP to a hostname or IP address accessible by your devices. Additionally the checkbox "Override inform host with controller hostname/IP" has to be checked, so that devices can connect to the controller during adoption (devices use the inform-endpoint during adoption).
 
@@ -68,7 +68,7 @@ In order to manually adopt a device take these steps:
 
 ```
 ssh ubnt@$AP-IP
-set-inform http://$address:8080/inform
+set-inform http://$address:8081/inform
 ```
 
 The default device password is `ubnt`. `$address` is the IP address of the host you are running this container on and `$AP-IP` is the Access Point IP address.
@@ -98,9 +98,9 @@ services:
     ports:
       - 3478:3478/udp
       - 10001:10001/udp
-      - 8080:8080
-      - 8443:8443
-      - 1900:1900/udp #optional
+      - 8081:8081
+      - 8442:8442
+      - 1899:1899/udp #optional
       - 8843:8843 #optional
       - 8880:8880 #optional
       - 6789:6789 #optional
@@ -119,9 +119,9 @@ docker run -d \
   -e MEM_STARTUP=1024M `#optional` \
   -p 3478:3478/udp \
   -p 10001:10001/udp \
-  -p 8080:8080 \
-  -p 8443:8443 \
-  -p 1900:1900/udp `#optional` \
+  -p 8081:8081 \
+  -p 8442:8442 \
+  -p 1899:1899/udp `#optional` \
   -p 8843:8843 `#optional` \
   -p 8880:8880 `#optional` \
   -p 6789:6789 `#optional` \
@@ -133,15 +133,15 @@ docker run -d \
 
 ## Parameters
 
-Container images are configured using parameters passed at runtime (such as those above). These parameters are separated by a colon and indicate `<external>:<internal>` respectively. For example, `-p 8080:80` would expose port `80` from inside the container to be accessible from the host's IP on port `8080` outside the container.
+Container images are configured using parameters passed at runtime (such as those above). These parameters are separated by a colon and indicate `<external>:<internal>` respectively. For example, `-p 8081:80` would expose port `80` from inside the container to be accessible from the host's IP on port `8081` outside the container.
 
 | Parameter | Function |
 | :----: | --- |
 | `-p 3478/udp` | Unifi STUN port |
 | `-p 10001/udp` | Required for AP discovery |
-| `-p 8080` | Required for device communication |
-| `-p 8443` | Unifi web admin port |
-| `-p 1900/udp` | Required for `Make controller discoverable on L2 network` option |
+| `-p 8081` | Required for device communication |
+| `-p 8442` | Unifi web admin port |
+| `-p 1899/udp` | Required for `Make controller discoverable on L2 network` option |
 | `-p 8843` | Unifi guest portal HTTPS redirect port |
 | `-p 8880` | Unifi guest portal HTTP redirect port |
 | `-p 6789` | For mobile throughput test |

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -19,7 +19,7 @@ repo_vars:
   - MULTIARCH='true'
   - CI='true'
   - CI_WEB='true'
-  - CI_PORT='8443'
+  - CI_PORT='8442'
   - CI_SSL='true'
   - CI_DELAY='180'
   - CI_DOCKERENV='TZ=US/Pacific'

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -32,13 +32,13 @@ param_usage_include_ports: true
 param_ports:
   - { external_port: "3478", internal_port: "3478/udp", port_desc: "Unifi STUN port" }
   - { external_port: "10001", internal_port: "10001/udp", port_desc: "Required for AP discovery" }
-  - { external_port: "8080", internal_port: "8080", port_desc: "Required for device communication" }
-  - { external_port: "8443", internal_port: "8443", port_desc: "Unifi web admin port" }
+  - { external_port: "8081", internal_port: "8081", port_desc: "Required for device communication" }
+  - { external_port: "8442", internal_port: "8442", port_desc: "Unifi web admin port" }
 param_usage_include_env: false
 
 opt_param_usage_include_ports: true
 opt_param_ports:
-  - { external_port: "1900", internal_port: "1900/udp", port_desc: "Required for `Make controller discoverable on L2 network` option" }
+  - { external_port: "1899", internal_port: "1899/udp", port_desc: "Required for `Make controller discoverable on L2 network` option" }
   - { external_port: "8843", internal_port: "8843", port_desc: "Unifi guest portal HTTPS redirect port" }
   - { external_port: "8880", internal_port: "8880", port_desc: "Unifi guest portal HTTP redirect port" }
   - { external_port: "6789", internal_port: "6789", port_desc: "For mobile throughput test" }
@@ -47,7 +47,7 @@ opt_param_ports:
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: |
-  The webui is at https://ip:8443, setup with the first run wizard.
+  The webui is at https://ip:8442, setup with the first run wizard.
 
   For Unifi to adopt other devices, e.g. an Access Point, it is required to change the inform IP address. Because Unifi runs inside Docker by default it uses an IP address not accessible by other devices. To change this go to Settings > System Settings > Controller Configuration and set the Controller Hostname/IP to a hostname or IP address accessible by your devices. Additionally the checkbox "Override inform host with controller hostname/IP" has to be checked, so that devices can connect to the controller during adoption (devices use the inform-endpoint during adoption).
 
@@ -55,7 +55,7 @@ app_setup_block: |
 
   ```
   ssh ubnt@$AP-IP
-  set-inform http://$address:8080/inform
+  set-inform http://$address:8081/inform
   ```
 
   The default device password is `ubnt`. `$address` is the IP address of the host you are running this container on and `$AP-IP` is the Access Point IP address.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-unifi-controller/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Currently this container has several conflicting port mappings with other popular containers.  Such as binhex-qbittorrentvpm (8080), PlexMediaServer (1900), and your own code-server (8443). -->

## Benefits of this PR and context:
<!--- This PR will help eliminate potential port mapping issues and prevent individual users from having to manually change it because of conflicts. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
