### PR TITLE
Changed application setup info to reflect Unifi UI changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The architectures supported by this image are:
 
 The webui is at https://ip:8443, setup with the first run wizard.
 
-For Unifi to adopt other devices, e.g. an Access Point, it is required to change the inform IP address. Because Unifi runs inside Docker by default it uses an IP address not accessible by other devices. To change this go to Settings > System Settings > Controller Configuration and set the Controller Hostname/IP to a hostname or IP address accessible by your devices. Additionally the checkbox "Override inform host with controller hostname/IP" has to be checked, so that devices can connect to the controller during adoption (devices use the inform-endpoint during adoption).
+For Unifi to adopt other devices, e.g. an Access Point, it is required to change the inform IP address. Because Unifi runs inside Docker by default it uses an IP address not accessible by other devices. To change this go to Settings > System > Other Configuration and set the Override Inform Host option to a hostname or IP address accessible by your devices (usually the IP of your Docker host). This is done so that devices can connect to the controller during adoption (devices use the inform-endpoint during adoption).
 
 In order to manually adopt a device take these steps:
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -49,7 +49,7 @@ app_setup_block_enabled: true
 app_setup_block: |
   The webui is at https://ip:8443, setup with the first run wizard.
 
-  For Unifi to adopt other devices, e.g. an Access Point, it is required to change the inform IP address. Because Unifi runs inside Docker by default it uses an IP address not accessible by other devices. To change this go to Settings > System Settings > Controller Configuration and set the Controller Hostname/IP to a hostname or IP address accessible by your devices. Additionally the checkbox "Override inform host with controller hostname/IP" has to be checked, so that devices can connect to the controller during adoption (devices use the inform-endpoint during adoption).
+  For Unifi to adopt other devices, e.g. an Access Point, it is required to change the inform IP address. Because Unifi runs inside Docker by default it uses an IP address not accessible by other devices. To change this go to Settings > System > Other Configuration and set the Override Inform Host option to a hostname or IP address accessible by your devices (usually the IP of your Docker host). This is done so that devices can connect to the controller during adoption (devices use the inform-endpoint during adoption).
 
   In order to manually adopt a device take these steps:
 


### PR DESCRIPTION
Had some trouble this morning because the Application Setup info on the README does not reflect the UI changes Unifi made in the latest versions of its controller software.

These changes should be reflected correctly otherwise people using this Docker image for their Unifi hardware will hit a while rendering the whole controller useless.

Not a big deal if one knows the software, but still.

I'm a PR virgin, so if I miss something / have to do something please let me know.