### PR TITLE
Fix ports order

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -30,10 +30,10 @@ opt_param_env_vars:
 
 param_usage_include_ports: true
 param_ports:
+  - { external_port: "8443", internal_port: "8443", port_desc: "Unifi web admin port" }
   - { external_port: "3478", internal_port: "3478/udp", port_desc: "Unifi STUN port" }
   - { external_port: "10001", internal_port: "10001/udp", port_desc: "Required for AP discovery" }
   - { external_port: "8080", internal_port: "8080", port_desc: "Required for device communication" }
-  - { external_port: "8443", internal_port: "8443", port_desc: "Unifi web admin port" }
 param_usage_include_env: false
 
 opt_param_usage_include_ports: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-unifi-controller/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
The generated [XML](https://github.com/linuxserver/templates/blob/5926e4eae860f503a7c89951e2813bf758460900/unraid/unifi-controller.xml#L64-L67) sets the first port 3478 as Web UI, which is not.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Sets port 8443 as Web UI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
