### PR TITLE
Basically revert #119

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -8,8 +8,4 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="aptalca"
 
 # add local files
-COPY root/ /
-
-# Volumes and Ports
-WORKDIR /usr/lib/unifi
-
+COPY root-armhf/ /

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Europe/London` | Specify a timezone to use (e.g. Europe/London) - [see list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) |
-| `-e MEM_LIMIT=1024` | Optionally change the Java memory limit. Set to `default` to reset to default |
-| `-e MEM_STARTUP=1024` | Optionally change the Java initial/minimum memory. Set to `default` to reset to default |
+| `-e MEM_LIMIT=1024` | Optionally change the Java memory limit (in Megabytes). Set to `default` to reset to default |
+| `-e MEM_STARTUP=1024` | Optionally change the Java initial/minimum memory (in Megabytes). Set to `default` to reset to default |
 | `-v /config` | All Unifi data stored here |
 
 ## Environment variables from files (Docker secrets)

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -35,8 +35,8 @@ param_env_vars:
 # optional container parameters
 opt_param_usage_include_env: true
 opt_param_env_vars:
-  - { env_var: "MEM_LIMIT", env_value: "1024", desc: "Optionally change the Java memory limit. Set to `default` to reset to default" }
-  - { env_var: "MEM_STARTUP", env_value: "1024", desc: "Optionally change the Java initial/minimum memory. Set to `default` to reset to default" }
+  - { env_var: "MEM_LIMIT", env_value: "1024", desc: "Optionally change the Java memory limit (in Megabytes). Set to `default` to reset to default" }
+  - { env_var: "MEM_STARTUP", env_value: "1024", desc: "Optionally change the Java initial/minimum memory (in Megabytes). Set to `default` to reset to default" }
 
 opt_param_usage_include_ports: true
 opt_param_ports:

--- a/root-armhf/etc/cont-init.d/50-armless
+++ b/root-armhf/etc/cont-init.d/50-armless
@@ -6,7 +6,7 @@ cat <<-EOF
     ********************************************************
     *                                                      *
     *                         !!!!                         *
-    *      This Unif-Controller image does not support     *
+    *     This Unifi-Controller image does not support     *
     *        32 bit ARM due to a lack of OS packages       *
     *                                                      *
     *                                                      *

--- a/root-armhf/etc/cont-init.d/50-armless
+++ b/root-armhf/etc/cont-init.d/50-armless
@@ -1,16 +1,15 @@
 #!/usr/bin/with-contenv bash
+# shellcheck shell=bash
 
-if [[ "$(uname -m)" == "armv7l" ]]; then
 cat <<-EOF
     ********************************************************
     ********************************************************
     *                                                      *
     *                         !!!!                         *
-    *     This Unifi-Controller image does not support     *
-    *   32 bit ARM due to lack of available OS packages    *
+    *      This Unif-Controller image does not support     *
+    *        32 bit ARM due to a lack of OS packages       *
     *                                                      *
     *                                                      *
     ********************************************************
     ********************************************************
 EOF
-fi

--- a/root/etc/cont-init.d/15-install
+++ b/root/etc/cont-init.d/15-install
@@ -1,10 +1,5 @@
 #!/usr/bin/with-contenv bash
 
-if [[ "$(uname -m)" == "armv7l" ]]; then
-    # We don't support armhf any more
-    exit 0
-fi
-
 if [[ ! -d /usr/lib/unifi/bin ]]; then
     echo "*** installing unifi packages ***"
     export DEBIAN_FRONTEND=noninteractive

--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -1,10 +1,5 @@
 #!/usr/bin/with-contenv bash
 
-if [[ "$(uname -m)" == "armv7l" ]]; then
-    # We don't support armhf any more
-    exit 0
-fi
-
 # create our folders
 mkdir -p \
     /config/{data,logs,run}

--- a/root/etc/cont-init.d/30-keygen
+++ b/root/etc/cont-init.d/30-keygen
@@ -1,10 +1,5 @@
 #!/usr/bin/with-contenv bash
 
-if [[ "$(uname -m)" == "armv7l" ]]; then
-    # We don't support armhf any more
-    exit 0
-fi
-
 # generate key
 [[ ! -f /config/data/keystore ]] && \
     keytool -genkey -keyalg RSA -alias unifi -keystore /config/data/keystore \

--- a/root/etc/services.d/unifi/run
+++ b/root/etc/services.d/unifi/run
@@ -1,12 +1,12 @@
 #!/usr/bin/with-contenv bash
 
-if [ -z ${MEM_LIMIT+x} ]; then
+if [[ -z ${MEM_LIMIT} ]] || [[ ${MEM_LIMIT} = "default" ]]; then
     MEM_LIMIT="1024"
 fi
 
 cd /config || exit
 
-if [ -z ${MEM_STARTUP+x} ]; then
+if [[ -z ${MEM_STARTUP} ]] || [[ ${MEM_STARTUP} = "default" ]]; then
     exec \
         s6-setuidgid abc java -Xmx"${MEM_LIMIT}M" -Dlog4j2.formatMsgNoLookups=true -jar /usr/lib/unifi/lib/ace.jar start;
 else

--- a/root/etc/services.d/unifi/run
+++ b/root/etc/services.d/unifi/run
@@ -1,11 +1,15 @@
 #!/usr/bin/with-contenv bash
 
-cd /config || exit
-
-if [[ "$(uname -m)" == "armv7l" ]]; then
-    # We don't support armhf any more
-    sleep infinity
+if [ -z ${MEM_LIMIT+x} ]; then
+    MEM_LIMIT="1024"
 fi
 
-exec \
-    s6-setuidgid abc java -Dlog4j2.formatMsgNoLookups=true -jar /usr/lib/unifi/lib/ace.jar start;
+cd /config || exit
+
+if [ -z ${MEM_STARTUP+x} ]; then
+    exec \
+        s6-setuidgid abc java -Xmx"${MEM_LIMIT}M" -Dlog4j2.formatMsgNoLookups=true -jar /usr/lib/unifi/lib/ace.jar start;
+else
+    exec \
+        s6-setuidgid abc java -Xms"${MEM_STARTUP}M" -Xmx"${MEM_LIMIT}M" -Dlog4j2.formatMsgNoLookups=true -jar /usr/lib/unifi/lib/ace.jar start;
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-unifi-controller/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Basically, #119 was implemented on the basis of invalid information and improperly executed tests. The original approach that we were using was correct, Ubnt do some bash gymnastics with their init scripts to extract the xmx/xms values from system.properties and inject them into an env which is then read by another init script and passed to the java cmd. As we don't use those scripts the values are never read from the file.

The init still writes to system.properties so it's consistent with what's been sent to the JVM, which means hopefully we avoid this confusion in the future.

Closes #160 

Also updated the armhf handling to be in line with newer images, using its own root folder.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
