### PR TITLE
If we can't write to /run then symlink pid to /config

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **10.03.23:** - Test writing to /run/unifi and symlink to /config/run if it fails.
 * **20.02.23:** - Migrate to s6v3, install deb package on build, fix permissions.
 * **23.01.23:** - Exclude `run` from `/config` volume.
 * **30.11.22:** - Bump JRE to 11.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -66,6 +66,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "10.03.23:", desc: "Test writing to /run/unifi and symlink to /config/run if it fails."}
   - { date: "20.02.23:", desc: "Migrate to s6v3, install deb package on build, fix permissions."}
   - { date: "23.01.23:", desc: "Exclude `run` from `/config` volume."}
   - { date: "30.11.22:", desc: "Bump JRE to 11."}

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -53,7 +53,7 @@ app_setup_block: |
 
   ### Please note, Unifi change the location of this option every few releases so if it's not where it says, search for "Inform" or "Inform Host" in the settings.
 
-  For Unifi to adopt other devices, e.g. an Access Point, it is required to change the inform IP address. Because Unifi runs inside Docker by default it uses an IP address not accessible by other devices. To change this go to Settings > System > Advanced > and set the Inform Host to a hostname or IP address accessible by your devices. Additionally the checkbox "Override" has to be checked, so that devices can connect to the controller during adoption (devices use the inform-endpoint during adoption).
+  For Unifi to adopt other devices, e.g. an Access Point, it is required to change the inform IP address. Because Unifi runs inside Docker by default it uses an IP address not accessible by other devices. To change this go to Settings > System > Advanced and set the Inform Host to a hostname or IP address accessible by your devices. Additionally the checkbox "Override" has to be checked, so that devices can connect to the controller during adoption (devices use the inform-endpoint during adoption).
 
   In order to manually adopt a device take these steps:
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -51,7 +51,9 @@ app_setup_block_enabled: true
 app_setup_block: |
   The webui is at https://ip:8443, setup with the first run wizard.
 
-  For Unifi to adopt other devices, e.g. an Access Point, it is required to change the inform IP address. Because Unifi runs inside Docker by default it uses an IP address not accessible by other devices. To change this go to Settings > System Settings > Controller Configuration and set the Controller Hostname/IP to a hostname or IP address accessible by your devices. Additionally the checkbox "Override inform host with controller hostname/IP" has to be checked, so that devices can connect to the controller during adoption (devices use the inform-endpoint during adoption).
+  ### Please note, Unifi change the location of this option every few releases so if it's not where it says, search for "Inform" or "Inform Host" in the settings.
+
+  For Unifi to adopt other devices, e.g. an Access Point, it is required to change the inform IP address. Because Unifi runs inside Docker by default it uses an IP address not accessible by other devices. To change this go to Settings > System > Advanced > and set the Inform Host to a hostname or IP address accessible by your devices. Additionally the checkbox "Override" has to be checked, so that devices can connect to the controller during adoption (devices use the inform-endpoint during adoption).
 
   In order to manually adopt a device take these steps:
 

--- a/root/etc/s6-overlay/s6-rc.d/init-unifi-controller-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-unifi-controller-config/run
@@ -90,7 +90,7 @@ lsiown abc:abc \
 	/run/unifi \
     /var/run/unifi
 
-if ! s6-setuidgid abc touch /run/unifi/monogo.test 2>/dev/null; then
+if ! s6-setuidgid abc touch /run/unifi/mongo.test 2>/dev/null; then
     if [[ ${S6_VERBOSITY} -ge 2 ]]; then
         echo "Write test to /run/unifi failed, symlinking to /config/run."
     fi
@@ -105,5 +105,5 @@ else
         echo "Write test to /run/unifi succeeded."
     fi
     chown abc:abc /usr/lib/unifi/run
-    rm /run/unifi/monogo.test
+    rm /run/unifi/mongo.test
 fi

--- a/root/etc/s6-overlay/s6-rc.d/init-unifi-controller-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-unifi-controller-config/run
@@ -83,21 +83,27 @@ fi
 
 # permissions
 lsiown -R abc:abc \
-	/config \
-	/run/unifi
+	/config
 
 lsiown abc:abc \
-    /config/data/keystore
+    /config/data/keystore \
+	/run/unifi \
+    /var/run/unifi
 
 if ! s6-setuidgid abc touch /run/unifi/monogo.test 2>/dev/null; then
     if [[ ${S6_VERBOSITY} -ge 2 ]]; then
         echo "Write test to /run/unifi failed, symlinking to /config/run."
     fi
+    if [[ -L "/usr/lib/unifi/run" ]]; then
+        unlink "/usr/lib/unifi/run"
+    fi
     mkdir -p /config/run
     ln -s "/config/run" "/usr/lib/unifi/run"
+    chown abc:abc /usr/lib/unifi/run
 else
     if [[ ${S6_VERBOSITY} -ge 2 ]]; then
         echo "Write test to /run/unifi succeeded."
     fi
+    chown abc:abc /usr/lib/unifi/run
     rm /run/unifi/monogo.test
 fi

--- a/root/etc/s6-overlay/s6-rc.d/init-unifi-controller-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-unifi-controller-config/run
@@ -90,8 +90,14 @@ lsiown abc:abc \
     /config/data/keystore
 
 if ! s6-setuidgid abc touch /run/unifi/monogo.test 2>/dev/null; then
+    if [[ ${S6_VERBOSITY} == "2" ]]; then
+        echo "Write test to /run/unifi failed, symlinking to /config/run."
+    fi
     mkdir -p /config/run
     ln -s "/config/run" "/usr/lib/unifi/run"
 else
+    if [[ ${S6_VERBOSITY} == "2" ]]; then
+        echo "Write test to /run/unifi succeeded."
+    fi
     rm /run/unifi/monogo.test
 fi

--- a/root/etc/s6-overlay/s6-rc.d/init-unifi-controller-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-unifi-controller-config/run
@@ -90,13 +90,13 @@ lsiown abc:abc \
     /config/data/keystore
 
 if ! s6-setuidgid abc touch /run/unifi/monogo.test 2>/dev/null; then
-    if [[ ${S6_VERBOSITY} == "2" ]]; then
+    if [[ ${S6_VERBOSITY} -ge 2 ]]; then
         echo "Write test to /run/unifi failed, symlinking to /config/run."
     fi
     mkdir -p /config/run
     ln -s "/config/run" "/usr/lib/unifi/run"
 else
-    if [[ ${S6_VERBOSITY} == "2" ]]; then
+    if [[ ${S6_VERBOSITY} -ge 2 ]]; then
         echo "Write test to /run/unifi succeeded."
     fi
     rm /run/unifi/monogo.test

--- a/root/etc/s6-overlay/s6-rc.d/init-unifi-controller-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-unifi-controller-config/run
@@ -88,3 +88,10 @@ lsiown -R abc:abc \
 
 lsiown abc:abc \
     /config/data/keystore
+
+if ! s6-setuidgid abc touch /run/unifi/monogo.test 2>/dev/null; then
+    mkdir -p /config/run
+    ln -s "/config/run" "/usr/lib/unifi/run"
+else
+    rm /run/unifi/monogo.test
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-unifi-controller/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Closes #195 

Not a fix for the root cause (still don't know what it is) but provides a workaround so images aren't broken for affected users, without reverting the change to stop the container breaking for people who couldn't write the .pid to their /config mount due to the filesystem.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
