### PR TITLE
Cleanup `apt-get install` to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,13 @@ ARG DEBIAN_FRONTEND="noninteractive"
 RUN \
   echo "**** install packages ****" && \
   apt-get update && \
-  apt-get install -y \
+  apt-get install -y --no-install-recommends \
     binutils \
     jsvc \
     libcap2 \
     logrotate \
     mongodb-server \
-    openjdk-11-jre-headless \
-    wget && \
+    openjdk-11-jre-headless && \
   echo "**** install unifi ****" && \
   if [ -z ${UNIFI_VERSION+x} ]; then \
     UNIFI_VERSION=$(curl -sX GET http://dl-origin.ubnt.com/unifi/debian/dists/${UNIFI_BRANCH}/ubiquiti/binary-amd64/Packages \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -16,14 +16,13 @@ ARG DEBIAN_FRONTEND="noninteractive"
 RUN \
   echo "**** install packages ****" && \
   apt-get update && \
-  apt-get install -y \
+  apt-get install -y --no-install-recommends \
     binutils \
     jsvc \
     libcap2 \
     logrotate \
     mongodb-server \
-    openjdk-11-jre-headless \
-    wget && \
+    openjdk-11-jre-headless && \
   echo "**** install unifi ****" && \
   if [ -z ${UNIFI_VERSION+x} ]; then \
     UNIFI_VERSION=$(curl -sX GET http://dl-origin.ubnt.com/unifi/debian/dists/${UNIFI_BRANCH}/ubiquiti/binary-amd64/Packages \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -71,6 +71,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "02.05.23:", desc: "Cleanup `apt-get install` during build to reduce image size."}
   - { date: "18.03.23:", desc: "Add mongoless branch."}
   - { date: "10.03.23:", desc: "Test writing to /run/unifi and symlink to /config/run if it fails."}
   - { date: "20.02.23:", desc: "Migrate to s6v3, install deb package on build, fix permissions."}


### PR DESCRIPTION
 - [x] I have read the [contributing](https://github.com/linuxserver/docker-unifi-controller/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
Without `--no-install-recommends` `apt-get` installs additional non-essential packages e.g. docs. This can be prevented and leads to a smaller image. In this case from **895 MB** to **784 MB**.

Also:
In https://github.com/linuxserver/docker-unifi-controller/commit/78f769b16e7f39fcc993e10af4f73b0bf61ac6ef `wget` was introduced as an installation requirement. This requirement was removed in https://github.com/linuxserver/docker-unifi-controller/commit/2c3eb9e5e0d811e4aa166f773e60c5e2fcc8a965 but wget was never dropped. This PR removes `wget` as it is not needed.

## Benefits of this PR and context:
Clean docker build and smaller image size.

## How Has This Been Tested?
`docker build -t docker-unify-controller --no-cache`


## Source / References:
--